### PR TITLE
Add configuration for node failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Changed
+- Update longhorn to 1.4.1
 - Set `Pod Deletion Policy When Node is Down` configuration to `delete-both-statefulset-and-deployment-pod`
-so that longhorn will delete stuck pods on a node failure #6
+  so that longhorn will delete stuck pods on a node failure #6
+
+## Fixed
+- Use correct annotations for the additional ces images #5
 
 ## [v1.3.1-4] - 2022-11-07
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Set `Pod Deletion Policy When Node is Down` configuration to `delete-both-statefulset-and-deployment-pod`
+so that longhorn will delete stuck pods on a node failure #6
 
 ## [v1.3.1-4] - 2022-11-07
 ## Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 ARTIFACT_ID=k8s-longhorn
 VERSION=1.3.1-4
-MAKEFILES_VERSION=7.0.1
+MAKEFILES_VERSION=7.5.0
 
 include build/make/variables.mk
 include build/make/k8s.mk
 include build/make/clean.mk
+include build/make/self-update.mk
 
 ##@ Release
 

--- a/build/make/k8s-controller.mk
+++ b/build/make/k8s-controller.mk
@@ -83,12 +83,12 @@ k8s-integration-test: $(K8S_INTEGRATION_TEST_DIR) manifests generate envtest ## 
 CONTROLLER_GEN = $(UTILITY_BIN_PATH)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.3)
 
 KUSTOMIZE = $(UTILITY_BIN_PATH)/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.7)
 
 ENVTEST = $(UTILITY_BIN_PATH)/setup-envtest
 .PHONY: envtest

--- a/build/make/k8s-dogu.mk
+++ b/build/make/k8s-dogu.mk
@@ -28,7 +28,7 @@ K8S_RESOURCE_PRODUCTIVE_YAML ?= $(K8S_RESOURCE_PRODUCTIVE_FOLDER)/$(ARTIFACT_ID)
 K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML ?= $(WORKDIR)/build/make/k8s-dogu.tpl
 # The pre generation script creates a k8s resource yaml containing the dogu crd and the content from the k8s folder.
 .PHONY: k8s-create-temporary-resource
- k8s-create-temporary-resource: ${BINARY_YQ}
+ k8s-create-temporary-resource: ${BINARY_YQ} $(K8S_RESOURCE_TEMP_FOLDER)
 	@echo "Generating temporary K8s resources $(K8S_RESOURCE_TEMP_YAML)..."
 	@rm -f $(K8S_RESOURCE_TEMP_YAML)
 	@sed "s|NAMESPACE|$(ARTIFACT_NAMESPACE)|g" $(K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML) | sed "s|NAME|$(ARTIFACT_ID)|g"  | sed "s|VERSION|$(VERSION)|g" >> $(K8S_RESOURCE_TEMP_YAML)
@@ -40,5 +40,5 @@ K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML ?= $(WORKDIR)/build/make/k8s-dogu.tpl
 install-dogu-descriptor: ${BINARY_YQ} $(TARGET_DIR) ## Installs a configmap with current dogu.json into the cluster.
 	@echo "Generate configmap from dogu.json..."
 	@$(BINARY_YQ) ".Image=\"${IMAGE_DEV_WITHOUT_TAG}\"" ${DOGU_JSON_FILE} > ${DOGU_JSON_DEV_FILE}
-	@kubectl create configmap "$(ARTIFACT_ID)-descriptor" --from-file=$(DOGU_JSON_DEV_FILE) --dry-run=client -o yaml | kubectl apply -f -
+	@kubectl create configmap "$(ARTIFACT_ID)-descriptor" --from-file=$(DOGU_JSON_DEV_FILE) --dry-run=client -o yaml | kubectl apply -f - --namespace=${NAMESPACE}
 	@echo "Done."

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -8,8 +8,6 @@ endif
 
 BINARY_YQ = $(UTILITY_BIN_PATH)/yq
 
-# The cluster root variable is used to the build images to the cluster. It can be defined in a .myenv file.
-K8S_CLUSTER_ROOT ?=
 # The productive tag of the image
 IMAGE ?=
 
@@ -22,17 +20,14 @@ K3CES_REGISTRY_URL_PREFIX="${K3S_CLUSTER_FQDN}:${K3S_LOCAL_REGISTRY_PORT}"
 K8S_RESOURCE_TEMP_FOLDER ?= $(TARGET_DIR)/make/k8s
 K8S_RESOURCE_TEMP_YAML ?= $(K8S_RESOURCE_TEMP_FOLDER)/$(ARTIFACT_ID)_$(VERSION).yaml
 
-# The current namespace is extracted from the current context.
-K8S_CURRENT_NAMESPACE=$(shell kubectl config view --minify -o jsonpath='{..namespace}')
-
 ##@ K8s - Variables
 
 .PHONY: check-all-vars
-check-all-vars: check-k8s-cluster-root-env-var check-k8s-image-env-var check-k8s-artifact-id check-etc-hosts check-insecure-cluster-registry ## Conduct a sanity check against selected build artefacts or local environment
+check-all-vars: check-k8s-image-env-var check-k8s-artifact-id check-etc-hosts check-insecure-cluster-registry check-k8s-namespace-env-var ## Conduct a sanity check against selected build artefacts or local environment
 
-.PHONY: check-k8s-cluster-root-env-var
-check-k8s-cluster-root-env-var:
-	@$(call check_defined, K8S_CLUSTER_ROOT, root path of your k3ces)
+.PHONY: check-k8s-namespace-env-var
+check-k8s-namespace-env-var:
+	@$(call check_defined, NAMESPACE, k8s namespace)
 
 .PHONY: check-k8s-image-env-var
 check-k8s-image-env-var:
@@ -60,7 +55,7 @@ ${K8S_RESOURCE_TEMP_FOLDER}:
 .PHONY: k8s-delete
 k8s-delete: k8s-generate $(K8S_POST_GENERATE_TARGETS) ## Deletes all dogu related resources from the K8s cluster.
 	@echo "Delete old dogu resources..."
-	@kubectl delete -f $(K8S_RESOURCE_TEMP_YAML) --wait=false --ignore-not-found=true
+	@kubectl delete -f $(K8S_RESOURCE_TEMP_YAML) --wait=false --ignore-not-found=true --namespace=${NAMESPACE}
 
 # The additional targets executed after the generate target, executed before each apply and delete. The generate target
 # produces a temporary yaml. This yaml is accessible via K8S_RESOURCE_TEMP_YAML an can be changed before the apply/delete.
@@ -71,14 +66,14 @@ K8S_PRE_GENERATE_TARGETS ?= k8s-create-temporary-resource
 .PHONY: k8s-generate
 k8s-generate: ${BINARY_YQ} $(K8S_RESOURCE_TEMP_FOLDER) $(K8S_PRE_GENERATE_TARGETS) ## Generates the final resource yaml.
 	@echo "Applying general transformations..."
-	@sed -i "s/'{{ .Namespace }}'/$(K8S_CURRENT_NAMESPACE)/" $(K8S_RESOURCE_TEMP_YAML)
+	@sed -i "s/'{{ .Namespace }}'/$(NAMESPACE)/" $(K8S_RESOURCE_TEMP_YAML)
 	@$(BINARY_YQ) -i e "(select(.kind == \"Deployment\").spec.template.spec.containers[]|select(.image == \"*$(ARTIFACT_ID)*\").image)=\"$(IMAGE_DEV)\"" $(K8S_RESOURCE_TEMP_YAML)
 	@echo "Done."
 
 .PHONY: k8s-apply
 k8s-apply: k8s-generate $(K8S_POST_GENERATE_TARGETS) ## Applies all generated K8s resources to the current cluster and namespace.
 	@echo "Apply generated K8s resources..."
-	@kubectl apply -f $(K8S_RESOURCE_TEMP_YAML)
+	@kubectl apply -f $(K8S_RESOURCE_TEMP_YAML) --namespace=${NAMESPACE}
 
 ##@ K8s - Docker
 

--- a/build/make/mockery.yaml
+++ b/build/make/mockery.yaml
@@ -1,0 +1,4 @@
+inpackage: True
+testonly: True
+with-expecter: True
+keeptree: False

--- a/build/make/mocks.mk
+++ b/build/make/mocks.mk
@@ -1,0 +1,27 @@
+##@ Mocking
+
+MOCKERY_BIN=${UTILITY_BIN_PATH}/mockery
+MOCKERY_VERSION=v2.20.0
+MOCKERY_YAML=${WORKDIR}/.mockery.yaml
+
+${MOCKERY_BIN}: ${UTILITY_BIN_PATH}
+	$(call go-get-tool,$(MOCKERY_BIN),github.com/vektra/mockery/v2@$(MOCKERY_VERSION))
+
+${MOCKERY_YAML}:
+	@cp ${WORKDIR}/build/make/mockery.yaml ${WORKDIR}/.mockery.yaml
+
+.PHONY: mocks
+mocks: ${MOCKERY_BIN} ${MOCKERY_YAML} ## This target is used to generate mocks for all interfaces in a project.
+	@for dir in ${WORKDIR}/*/ ;\
+ 		do \
+ 		# removes trailing '/' \
+		dir=$${dir%*/} ;\
+		# removes everything before the last '/' \
+		dir=$${dir##*/} ;\
+		if ! echo '${MOCKERY_IGNORED}' | egrep -q "\b$${dir}\b" ;\
+		then \
+		  	echo "Creating mocks for $${dir}" ;\
+			${MOCKERY_BIN} --all --dir $${dir} ;\
+		fi ;\
+ 	done ;
+	@echo "Mocks successfully created."

--- a/build/make/variables.mk
+++ b/build/make/variables.mk
@@ -19,7 +19,7 @@ GO_BUILD_TAG_INTEGRATION_TEST?=integration
 GOMODULES=on
 UTILITY_BIN_PATH?=${WORKDIR}/.bin
 
-SRC:=$(shell find "${WORKDIR}" -type f -name "*.go" -not -path "./vendor/*")
+SRC:=$(shell find "${WORKDIR}" -type f -name "*.go" -not -path "*/vendor/*")
 
 # debian stuff
 DEBIAN_BUILD_DIR=$(BUILD_DIR)/deb
@@ -62,6 +62,10 @@ $(ETCGROUP): $(TMP_DIR)
 
 $(UTILITY_BIN_PATH):
 	@mkdir -p $@
+
+# Subdirectories of workdir where no mocks should be generated.
+# Multiple directories can be separated by space, comma or whatever is not a word to regex.
+MOCKERY_IGNORED=vendor,build,docs
 
 ##@ General
 

--- a/manifests/longhorn.yaml
+++ b/manifests/longhorn.yaml
@@ -5,48 +5,19 @@ kind: Namespace
 metadata:
   name: longhorn-system
   annotations:
-    k8s-cloudogu-registry/additional-images/1: "longhornio/csi-attacher:v3.4.0"
-    k8s-cloudogu-registry/additional-images/2: "longhornio/csi-provisioner:v2.1.2"
-    k8s-cloudogu-registry/additional-images/3: "longhornio/csi-resizer:v1.2.0"
-    k8s-cloudogu-registry/additional-images/4: "longhornio/csi-snapshotter:v3.0.3"
-    k8s-cloudogu-registry/additional-images/5: "longhornio/csi-node-driver-registrar:v2.5.0"
-    k8s-cloudogu-registry/additional-images/6: "longhornio/longhorn-instance-manager:v1_20220808"
-    k8s-cloudogu-registry/additional-images/7: "longhornio/longhorn-engine:v1.3.1"
----
-# Source: longhorn/templates/psp.yaml
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: longhorn-psp
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
-spec:
-  privileged: true
-  allowPrivilegeEscalation: true
-  requiredDropCapabilities:
-    - NET_RAW
-  allowedCapabilities:
-    - SYS_ADMIN
-  hostNetwork: false
-  hostIPC: false
-  hostPID: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  fsGroup:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-    - configMap
-    - downwardAPI
-    - emptyDir
-    - secret
-    - projected
-    - hostPath
+    k8s-ces-additional-image-1: "longhornio/csi-attacher:v3.4.0"
+    k8s-ces-additional-image-2: "longhornio/csi-provisioner:v2.1.2"
+    k8s-ces-additional-image-3: "longhornio/csi-resizer:v1.3.0"
+    k8s-ces-additional-image-4: "longhornio/csi-snapshotter:v5.0.1"
+    k8s-ces-additional-image-5: "longhornio/csi-node-driver-registrar:v2.5.0"
+    k8s-ces-additional-image-6: "longhornio/livenessprobe:v2.8.0"
+    k8s-ces-additional-image-7: "longhornio/backing-image-manager:v1.4.1"
+    k8s-ces-additional-image-8: "longhornio/longhorn-engine:v1.4.1"
+    k8s-ces-additional-image-9: "longhornio/longhorn-instance-manager:v1.4.1"
+    k8s-ces-additional-image-10: "longhornio/longhorn-manager:v1.4.1"
+    k8s-ces-additional-image-11: "longhornio/longhorn-share-manager:v1.4.1"
+    k8s-ces-additional-image-12: "longhornio/longhorn-ui:v1.4.1"
+    k8s-ces-additional-image-13: "longhornio/support-bundle-kit:v0.0.19"
 ---
 # Source: longhorn/templates/serviceaccount.yaml
 apiVersion: v1
@@ -57,7 +28,18 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
+---
+# Source: longhorn/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-support-bundle
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.4.1
 ---
 # Source: longhorn/templates/default-setting.yaml
 apiVersion: v1
@@ -68,7 +50,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
 data:
   default-setting.yaml: |-
     node-down-pod-deletion-policy: delete-both-statefulset-and-deployment-pod
@@ -82,7 +64,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
 data:
   storageclass.yaml: |
     kind: StorageClass
@@ -108,11 +90,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: backingimagedatasources.longhorn.io
 spec:
@@ -283,7 +264,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: backingimagemanagers.longhorn.io
 spec:
@@ -468,7 +449,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: backingimages.longhorn.io
 spec:
@@ -643,7 +624,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: backups.longhorn.io
 spec:
@@ -836,7 +817,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: backuptargets.longhorn.io
 spec:
@@ -1019,7 +1000,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: backupvolumes.longhorn.io
 spec:
@@ -1183,7 +1164,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: engineimages.longhorn.io
 spec:
@@ -1375,7 +1356,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: engines.longhorn.io
 spec:
@@ -1499,6 +1480,8 @@ spec:
                   type: boolean
                 salvageRequested:
                   type: boolean
+                unmapMarkSnapChainRemovedEnabled:
+                  type: boolean
                 upgradedReplicaAddressMap:
                   additionalProperties:
                     type: string
@@ -1548,6 +1531,30 @@ spec:
                     type: object
                   nullable: true
                   type: object
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition. Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
                 currentImage:
                   type: string
                 currentReplicaAddressMap:
@@ -1673,6 +1680,8 @@ spec:
                   type: boolean
                 storageIP:
                   type: string
+                unmapMarkSnapChainRemovedEnabled:
+                  type: boolean
               type: object
           type: object
       served: true
@@ -1696,7 +1705,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: instancemanagers.longhorn.io
 spec:
@@ -1781,7 +1790,7 @@ spec:
               description: InstanceManagerSpec defines the desired state of the Longhorn instancer manager
               properties:
                 engineImage:
-                  description: 'TODO: deprecate this field'
+                  description: 'Deprecated: This field is useless.'
                   type: string
                 image:
                   type: string
@@ -1866,7 +1875,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: nodes.longhorn.io
 spec:
@@ -2072,6 +2081,14 @@ spec:
                   type: object
                 region:
                   type: string
+                snapshotCheckStatus:
+                  properties:
+                    lastPeriodicCheckedAt:
+                      format: date-time
+                      type: string
+                    snapshotCheckState:
+                      type: string
+                  type: object
                 zone:
                   type: string
               type: object
@@ -2097,7 +2114,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: orphans.longhorn.io
 spec:
@@ -2266,7 +2283,7 @@ spec:
           jsonPath: .spec.groups
           name: Groups
           type: string
-        - description: Should be one of "backup" or "snapshot"
+        - description: Should be one of "snapshot", "snapshot-cleanup", "snapshot-delete" or "backup"
           jsonPath: .spec.task
           name: Task
           type: string
@@ -2328,9 +2345,11 @@ spec:
                   description: The retain count of the snapshot/backup.
                   type: integer
                 task:
-                  description: The recurring job type. Can be "snapshot" or "backup".
+                  description: The recurring job task. Can be "snapshot", "snapshot-cleanup", "snapshot-delete" or "backup".
                   enum:
                     - snapshot
+                    - snapshot-cleanup
+                    - snapshot-delete
                     - backup
                   type: string
               type: object
@@ -2363,7 +2382,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: replicas.longhorn.io
 spec:
@@ -2501,6 +2520,8 @@ spec:
                   type: boolean
                 salvageRequested:
                   type: boolean
+                unmapMarkDiskChainRemovedEnabled:
+                  type: boolean
                 volumeName:
                   type: string
                 volumeSize:
@@ -2510,6 +2531,30 @@ spec:
             status:
               description: ReplicaStatus defines the observed state of the Longhorn replica
               properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition. Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
                 currentImage:
                   type: string
                 currentState:
@@ -2555,7 +2600,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: settings.longhorn.io
 spec:
@@ -2646,7 +2691,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: sharemanagers.longhorn.io
 spec:
@@ -2757,7 +2802,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: snapshots.longhorn.io
 spec:
@@ -2829,6 +2874,8 @@ spec:
             status:
               description: SnapshotStatus defines the observed state of Longhorn Snapshot
               properties:
+                checksum:
+                  type: string
                 children:
                   additionalProperties:
                     type: boolean
@@ -2878,10 +2925,362 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
+    longhorn-manager: ""
+  name: supportbundles.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SupportBundle
+    listKind: SupportBundleList
+    plural: supportbundles
+    shortNames:
+      - lhbundle
+    singular: supportbundle
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The state of the support bundle
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The issue URL
+          jsonPath: .spec.issueURL
+          name: Issue
+          type: string
+        - description: A brief description of the issue
+          jsonPath: .spec.description
+          name: Description
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: SupportBundle is where Longhorn stores support bundle object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SupportBundleSpec defines the desired state of the Longhorn SupportBundle
+              properties:
+                description:
+                  description: A brief description of the issue
+                  type: string
+                issueURL:
+                  description: The issue URL
+                  nullable: true
+                  type: string
+                nodeID:
+                  description: The preferred responsible controller node ID.
+                  type: string
+              required:
+                - description
+              type: object
+            status:
+              description: SupportBundleStatus defines the observed state of the Longhorn SupportBundle
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition. Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                filename:
+                  type: string
+                filesize:
+                  format: int64
+                  type: integer
+                image:
+                  description: The support bundle manager image
+                  type: string
+                managerIP:
+                  description: The support bundle manager IP
+                  type: string
+                ownerID:
+                  description: The current responsible controller node ID
+                  type: string
+                progress:
+                  type: integer
+                state:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.4.1
+    longhorn-manager: ""
+  name: systembackups.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SystemBackup
+    listKind: SystemBackupList
+    plural: systembackups
+    shortNames:
+      - lhsb
+    singular: systembackup
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The system backup Longhorn version
+          jsonPath: .status.version
+          name: Version
+          type: string
+        - description: The system backup state
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The system backup creation time
+          jsonPath: .status.createdAt
+          name: Created
+          type: string
+        - description: The last time that the system backup was synced into the cluster
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: SystemBackup is where Longhorn stores system backup object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SystemBackupSpec defines the desired state of the Longhorn SystemBackup
+              type: object
+            status:
+              description: SystemBackupStatus defines the observed state of the Longhorn SystemBackup
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition. Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                createdAt:
+                  description: The system backup creation time.
+                  format: date-time
+                  type: string
+                gitCommit:
+                  description: The saved Longhorn manager git commit.
+                  nullable: true
+                  type: string
+                lastSyncedAt:
+                  description: The last time that the system backup was synced into the cluster.
+                  format: date-time
+                  nullable: true
+                  type: string
+                managerImage:
+                  description: The saved manager image.
+                  type: string
+                ownerID:
+                  description: The node ID of the responsible controller to reconcile this SystemBackup.
+                  type: string
+                state:
+                  description: The system backup state.
+                  type: string
+                version:
+                  description: The saved Longhorn version.
+                  nullable: true
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.4.1
+    longhorn-manager: ""
+  name: systemrestores.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SystemRestore
+    listKind: SystemRestoreList
+    plural: systemrestores
+    shortNames:
+      - lhsr
+    singular: systemrestore
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The system restore state
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: SystemRestore is where Longhorn stores system restore object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SystemRestoreSpec defines the desired state of the Longhorn SystemRestore
+              properties:
+                systemBackup:
+                  description: The system backup name in the object store.
+                  type: string
+              required:
+                - systemBackup
+              type: object
+            status:
+              description: SystemRestoreStatus defines the observed state of the Longhorn SystemRestore
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition. Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                ownerID:
+                  description: The node ID of the responsible controller to reconcile this SystemRestore.
+                  type: string
+                sourceURL:
+                  description: The source system backup URL.
+                  type: string
+                state:
+                  description: The system restore state.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.4.1
     longhorn-manager: ""
   name: volumes.longhorn.io
 spec:
@@ -3010,6 +3409,7 @@ spec:
                   enum:
                     - disabled
                     - best-effort
+                    - strict-local
                   type: string
                 dataSource:
                   type: string
@@ -3024,6 +3424,12 @@ spec:
                 engineImage:
                   type: string
                 fromBackup:
+                  type: string
+                restoreVolumeRecurringJob:
+                  enum:
+                    - ignored
+                    - enabled
+                    - disabled
                   type: string
                 frontend:
                   enum:
@@ -3048,7 +3454,7 @@ spec:
                 recurringJobs:
                   description: Deprecated. Replaced by a separate resource named "RecurringJob"
                   items:
-                    description: 'VolumeRecurringJobSpec is a deprecated struct. TODO: Should be removed when recurringJobs gets removed from the volume       spec.'
+                    description: 'Deprecated: This field is useless and has been replaced by the RecurringJob CRD'
                     properties:
                       concurrency:
                         type: integer
@@ -3069,6 +3475,8 @@ spec:
                       task:
                         enum:
                           - snapshot
+                          - snapshot-cleanup
+                          - snapshot-delete
                           - backup
                         type: string
                     type: object
@@ -3085,8 +3493,21 @@ spec:
                 size:
                   format: int64
                   type: string
+                snapshotDataIntegrity:
+                  enum:
+                    - ignored
+                    - disabled
+                    - enabled
+                    - fast-check
+                  type: string
                 staleReplicaTimeout:
                   type: integer
+                unmapMarkSnapChainRemoved:
+                  enum:
+                    - ignored
+                    - disabled
+                    - enabled
+                  type: string
               type: object
             status:
               description: VolumeStatus defines the observed state of the Longhorn volume
@@ -3213,7 +3634,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
 rules:
   - apiGroups:
       - apiextensions.k8s.io
@@ -3222,7 +3643,7 @@ rules:
     verbs:
       - "*"
   - apiGroups: [""]
-    resources: ["pods", "events", "persistentvolumes", "persistentvolumeclaims","persistentvolumeclaims/status", "nodes", "proxy/nodes", "pods/log", "secrets", "services", "endpoints", "configmaps"]
+    resources: ["pods", "events", "persistentvolumes", "persistentvolumeclaims","persistentvolumeclaims/status", "nodes", "proxy/nodes", "pods/log", "secrets", "services", "endpoints", "configmaps", "serviceaccounts"]
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["namespaces"]
@@ -3234,7 +3655,7 @@ rules:
     resources: ["jobs", "cronjobs"]
     verbs: ["*"]
   - apiGroups: ["policy"]
-    resources: ["poddisruptionbudgets"]
+    resources: ["poddisruptionbudgets", "podsecuritypolicies"]
     verbs: ["*"]
   - apiGroups: ["scheduling.k8s.io"]
     resources: ["priorityclasses"]
@@ -3251,7 +3672,8 @@ rules:
                 "sharemanagers", "sharemanagers/status", "backingimages", "backingimages/status",
                 "backingimagemanagers", "backingimagemanagers/status", "backingimagedatasources", "backingimagedatasources/status",
                 "backuptargets", "backuptargets/status", "backupvolumes", "backupvolumes/status", "backups", "backups/status",
-                "recurringjobs", "recurringjobs/status", "orphans", "orphans/status", "snapshots", "snapshots/status"]
+                "recurringjobs", "recurringjobs/status", "orphans", "orphans/status", "snapshots", "snapshots/status",
+                "supportbundles", "supportbundles/status", "systembackups", "systembackups/status", "systemrestores", "systemrestores/status"]
     verbs: ["*"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -3265,6 +3687,9 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
     verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings", "clusterrolebindings", "clusterroles"]
+    verbs: ["*"]
 ---
 # Source: longhorn/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3274,7 +3699,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -3284,46 +3709,22 @@ subjects:
     name: longhorn-service-account
     namespace: longhorn-system
 ---
-# Source: longhorn/templates/psp.yaml
+# Source: longhorn/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRoleBinding
 metadata:
-  name: longhorn-psp-role
+  name: longhorn-support-bundle
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
-  namespace: longhorn-system
-rules:
-  - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
-    verbs:
-      - use
-    resourceNames:
-      - longhorn-psp
----
-# Source: longhorn/templates/psp.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: longhorn-psp-binding
-  labels:
-    app.kubernetes.io/name: longhorn
-    app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
-  namespace: longhorn-system
+    app.kubernetes.io/version: v1.4.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: longhorn-psp-role
+  kind: ClusterRole
+  name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: longhorn-service-account
-    namespace: longhorn-system
-  - kind: ServiceAccount
-    name: default
+    name: longhorn-support-bundle
     namespace: longhorn-system
 ---
 # Source: longhorn/templates/daemonset-sa.yaml
@@ -3333,7 +3734,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     app: longhorn-manager
   name: longhorn-backend
   namespace: longhorn-system
@@ -3354,7 +3755,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     app: longhorn-ui
   name: longhorn-frontend
   namespace: longhorn-system
@@ -3375,7 +3776,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     app: longhorn-conversion-webhook
   name: longhorn-conversion-webhook
   namespace: longhorn-system
@@ -3396,7 +3797,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     app: longhorn-admission-webhook
   name: longhorn-admission-webhook
   namespace: longhorn-system
@@ -3417,7 +3818,28 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
+    app: longhorn-recovery-backend
+  name: longhorn-recovery-backend
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  sessionAffinity: ClientIP
+  selector:
+    app: longhorn-recovery-backend
+  ports:
+    - name: recovery-backend
+      port: 9600
+      targetPort: recov-backend
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.4.1
   name: longhorn-engine-manager
   namespace: longhorn-system
 spec:
@@ -3433,7 +3855,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
   name: longhorn-replica-manager
   namespace: longhorn-system
 spec:
@@ -3449,7 +3871,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     app: longhorn-manager
   name: longhorn-manager
   namespace: longhorn-system
@@ -3462,16 +3884,16 @@ spec:
       labels:
         app.kubernetes.io/name: longhorn
         app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.3.1
+        app.kubernetes.io/version: v1.4.1
         app: longhorn-manager
     spec:
       initContainers:
         - name: wait-longhorn-admission-webhook
-          image: longhornio/longhorn-manager:v1.3.1
+          image: longhornio/longhorn-manager:v1.4.1
           command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" -k https://longhorn-admission-webhook:9443/v1/healthz) != "200" ]; do echo waiting; sleep 2; done']
       containers:
         - name: longhorn-manager
-          image: longhornio/longhorn-manager:v1.3.1
+          image: longhornio/longhorn-manager:v1.4.1
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -3480,15 +3902,17 @@ spec:
             - -d
             - daemon
             - --engine-image
-            - "longhornio/longhorn-engine:v1.3.1"
+            - "longhornio/longhorn-engine:v1.4.1"
             - --instance-manager-image
-            - "longhornio/longhorn-instance-manager:v1_20220808"
+            - "longhornio/longhorn-instance-manager:v1.4.1"
             - --share-manager-image
-            - "longhornio/longhorn-share-manager:v1_20220808"
+            - "longhornio/longhorn-share-manager:v1.4.1"
             - --backing-image-manager-image
-            - "longhornio/backing-image-manager:v3_20220808"
+            - "longhornio/backing-image-manager:v1.4.1"
+            - --support-bundle-manager-image
+            - "longhornio/support-bundle-kit:v0.0.19"
             - --manager-image
-            - "longhornio/longhorn-manager:v1.3.1"
+            - "longhornio/longhorn-manager:v1.4.1"
             - --service-account
             - longhorn-service-account
           ports:
@@ -3548,7 +3972,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
 spec:
   replicas: 1
   selector:
@@ -3559,23 +3983,23 @@ spec:
       labels:
         app.kubernetes.io/name: longhorn
         app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.3.1
+        app.kubernetes.io/version: v1.4.1
         app: longhorn-driver-deployer
     spec:
       initContainers:
         - name: wait-longhorn-manager
-          image: longhornio/longhorn-manager:v1.3.1
+          image: longhornio/longhorn-manager:v1.4.1
           command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
       containers:
         - name: longhorn-driver-deployer
-          image: longhornio/longhorn-manager:v1.3.1
+          image: longhornio/longhorn-manager:v1.4.1
           imagePullPolicy: IfNotPresent
           command:
             - longhorn-manager
             - -d
             - deploy-driver
             - --manager-image
-            - "longhornio/longhorn-manager:v1.3.1"
+            - "longhornio/longhorn-manager:v1.4.1"
             - --manager-url
             - http://longhorn-backend:9500/v1
           env:
@@ -3598,12 +4022,80 @@ spec:
             - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
               value: "longhornio/csi-node-driver-registrar:v2.5.0"
             - name: CSI_RESIZER_IMAGE
-              value: "longhornio/csi-resizer:v1.2.0"
+              value: "longhornio/csi-resizer:v1.3.0"
             - name: CSI_SNAPSHOTTER_IMAGE
-              value: "longhornio/csi-snapshotter:v3.0.3"
+              value: "longhornio/csi-snapshotter:v5.0.1"
+            - name: CSI_LIVENESS_PROBE_IMAGE
+              value: "longhornio/livenessprobe:v2.8.0"
       serviceAccountName: longhorn-service-account
       securityContext:
         runAsUser: 0
+---
+# Source: longhorn/templates/deployment-recovery-backend.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.4.1
+    app: longhorn-recovery-backend
+  name: longhorn-recovery-backend
+  namespace: longhorn-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: longhorn-recovery-backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.4.1
+        app: longhorn-recovery-backend
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - longhorn-recovery-backend
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: longhorn-recovery-backend
+          image: longhornio/longhorn-manager:v1.4.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 2000
+          command:
+            - longhorn-manager
+            - recovery-backend
+            - --service-account
+            - longhorn-service-account
+          ports:
+            - containerPort: 9600
+              name: recov-backend
+          readinessProbe:
+            tcpSocket:
+              port: 9600
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      serviceAccountName: longhorn-service-account
 ---
 # Source: longhorn/templates/deployment-ui.yaml
 apiVersion: apps/v1
@@ -3612,12 +4104,12 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     app: longhorn-ui
   name: longhorn-ui
   namespace: longhorn-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: longhorn-ui
@@ -3626,12 +4118,24 @@ spec:
       labels:
         app.kubernetes.io/name: longhorn
         app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.3.1
+        app.kubernetes.io/version: v1.4.1
         app: longhorn-ui
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - longhorn-ui
+                topologyKey: kubernetes.io/hostname
       containers:
         - name: longhorn-ui
-          image: longhornio/longhorn-ui:v1.3.1
+          image: longhornio/longhorn-ui:v1.4.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name : nginx-cache
@@ -3663,7 +4167,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     app: longhorn-conversion-webhook
   name: longhorn-conversion-webhook
   namespace: longhorn-system
@@ -3677,7 +4181,7 @@ spec:
       labels:
         app.kubernetes.io/name: longhorn
         app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.3.1
+        app.kubernetes.io/version: v1.4.1
         app: longhorn-conversion-webhook
     spec:
       affinity:
@@ -3694,7 +4198,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: longhorn-conversion-webhook
-          image: longhornio/longhorn-manager:v1.3.1
+          image: longhornio/longhorn-manager:v1.4.1
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 2000
@@ -3723,7 +4227,7 @@ metadata:
   labels:
     app.kubernetes.io/name: longhorn
     app.kubernetes.io/instance: longhorn
-    app.kubernetes.io/version: v1.3.1
+    app.kubernetes.io/version: v1.4.1
     app: longhorn-admission-webhook
   name: longhorn-admission-webhook
   namespace: longhorn-system
@@ -3737,7 +4241,7 @@ spec:
       labels:
         app.kubernetes.io/name: longhorn
         app.kubernetes.io/instance: longhorn
-        app.kubernetes.io/version: v1.3.1
+        app.kubernetes.io/version: v1.4.1
         app: longhorn-admission-webhook
     spec:
       affinity:
@@ -3754,14 +4258,14 @@ spec:
                 topologyKey: kubernetes.io/hostname
       initContainers:
         - name: wait-longhorn-conversion-webhook
-          image: longhornio/longhorn-manager:v1.3.1
+          image: longhornio/longhorn-manager:v1.4.1
           command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" -k https://longhorn-conversion-webhook:9443/v1/healthz) != "200" ]; do echo waiting; sleep 2; done']
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 2000
       containers:
         - name: longhorn-admission-webhook
-          image: longhornio/longhorn-manager:v1.3.1
+          image: longhornio/longhorn-manager:v1.4.1
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 2000
@@ -3786,3 +4290,6 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
       serviceAccountName: longhorn-service-account
+---
+# Source: longhorn/templates/validate-psp-install.yaml
+#

--- a/manifests/longhorn.yaml
+++ b/manifests/longhorn.yaml
@@ -19,6 +19,68 @@ metadata:
     k8s-ces-additional-image-12: "longhornio/longhorn-ui:v1.4.1"
     k8s-ces-additional-image-13: "longhornio/support-bundle-kit:v0.0.19"
 ---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: longhorn-psp
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+    - NET_RAW
+  allowedCapabilities:
+    - SYS_ADMIN
+  hostNetwork: false
+  hostIPC: false
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - configMap
+    - downwardAPI
+    - emptyDir
+    - secret
+    - projected
+    - hostPath
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: longhorn-psp-role
+  namespace: longhorn-system
+rules:
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - longhorn-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-psp-binding
+  namespace: longhorn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: longhorn-psp-role
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-service-account
+    namespace: longhorn-system
+  - kind: ServiceAccount
+    name: default
+    namespace: longhorn-system
+---
 # Source: longhorn/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/manifests/longhorn.yaml
+++ b/manifests/longhorn.yaml
@@ -19,6 +19,7 @@ metadata:
     k8s-ces-additional-image-12: "longhornio/longhorn-ui:v1.4.1"
     k8s-ces-additional-image-13: "longhornio/support-bundle-kit:v0.0.19"
 ---
+# Source: deploy/podsecuritypolicy.yaml
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/manifests/longhorn.yaml
+++ b/manifests/longhorn.yaml
@@ -71,6 +71,7 @@ metadata:
     app.kubernetes.io/version: v1.3.1
 data:
   default-setting.yaml: |-
+    node-down-pod-deletion-policy: delete-both-statefulset-and-deployment-pod
 ---
 # Source: longhorn/templates/storageclass.yaml
 apiVersion: v1

--- a/manifests/longhorn.yaml
+++ b/manifests/longhorn.yaml
@@ -4354,5 +4354,3 @@ spec:
                   fieldPath: spec.nodeName
       serviceAccountName: longhorn-service-account
 ---
-# Source: longhorn/templates/validate-psp-install.yaml
-#


### PR DESCRIPTION
Configure `Pod Deletion Policy When Node is Down` so that longhorn will delete stuck pods on a node failure.

Resolves #6 

Upgrade longhorn to 1.4.1 and use correct annotations for the additional ces images

Resolves #5 